### PR TITLE
upgrade: swap clor for turbocolor

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "Jari Zwarts <jarizw@gmail.com>",
   "license": "ISC",
   "dependencies": {
-    "clor": "^1.0.2",
+    "turbocolor": "^2.3.0",
     "coffee-script": "^1.10.0",
     "commander": "^2.8.1",
     "ffmetadata": "^1.3.0",

--- a/scdl-cli.coffee
+++ b/scdl-cli.coffee
@@ -1,7 +1,7 @@
 multimeter = require 'multimeter'
 multi = multimeter(process);
 scdl = require './scdl'
-clor = require 'clor'
+tc = require 'turbocolor'
 cmd = require 'commander'
 log = require('./log')()
 path = require "path"
@@ -12,8 +12,8 @@ module.exports = ->
   multi.charm.setMaxListeners 100;
 
   multi.charm.reset();
-  console.log clor.white("SoundCloud Downloader").bold() + clor.gray(" By Jari Zwarts")
-  clor.yellow("Automatically downloads and tags SoundCloud tracks/playlists").log()
+  console.log tc.bold.white("SoundCloud Downloader") + tc.gray(" By Jari Zwarts")
+  console.log tc.yellow("Automatically downloads and tags SoundCloud tracks/playlists")
 
   cmd.version("0.1")
     .usage("[options] <url>")


### PR DESCRIPTION
Hi @jariz, thank you for using clor! I've deprecated the pkg some time ago so this PR upgrades you to its latest incarnation, [turbocolor](https://github.com/jorgebucaran/turbocolor), which is lighter and faster. In addition, we don't need to coerce strings, and as a result of that, the coloring code has become a bit simpler.

Let me know if this looks good to you! 